### PR TITLE
Remove redundant scp of docker-compose.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Copy Docker image and compose file to remote server
         run: |
           scp grh-website_${{ github.sha }}.tar ${{ secrets.SERVER_USER }}@${{ secrets.SERVER_IP }}:/home/${{ secrets.SERVER_USER }}/grh-website_${{ github.sha }}.tar
-          scp docker-compose.yml ${{ secrets.SERVER_USER }}@${{ secrets.SERVER_IP }}:/home/${{ secrets.SERVER_USER }}/docker-compose.yml
+          
 
       - name: Load and run Docker container on remote server
         run: |


### PR DESCRIPTION
The docker-compose.yml file no longer needs to be copied to the remote server, as it is either not required or already present. This simplifies the deployment workflow and reduces potential errors or redundancies.