### PR TITLE
Update deployment workflow for container restart

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,5 +46,6 @@ jobs:
             docker load -i /home/${{ secrets.SERVER_USER }}/grh-website_${{ github.sha }}.tar
             export FRONTENDTAG=${{ github.sha }}
             cd /home/${{ secrets.SERVER_USER }}/
-            docker compose up -d
-
+            docker compose stop grh-website
+            docker compose rm -f grh-website
+            docker compose up -d grh-website


### PR DESCRIPTION
Previously, the workflow only brought up the container without stopping or removing the existing one. This change ensures the current instance of `grh-website` is stopped and removed before restarting, allowing for a clean deployment process.