### PR TITLE
Rename Docker service in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,6 +46,6 @@ jobs:
             docker load -i /home/${{ secrets.SERVER_USER }}/grh-website_${{ github.sha }}.tar
             export FRONTENDTAG=${{ github.sha }}
             cd /home/${{ secrets.SERVER_USER }}/
-            docker compose stop grh-website
-            docker compose rm -f grh-website
-            docker compose up -d grh-website
+            docker compose stop frontend
+            docker compose rm -f frontend
+            docker compose up -d frontend


### PR DESCRIPTION
Updated the deploy workflow to rename the Docker service from `grh-website` to `frontend`. This ensures consistency with the naming convention used elsewhere in the codebase.