### PR TITLE
Fix Nginx start command in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,4 @@ COPY --from=build /app/build /usr/share/nginx/html
 EXPOSE 80
 
 # Step 10: Start Nginx server
-CMD ["nginx", "-s", "daemon off;"]
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
Corrected the Nginx CMD instruction from using '-s' to '-g'. This ensures the Nginx server runs in the foreground as intended.