### PR TITLE
Fix Docker save command in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
         run: docker build -t grh-website:latest-test .
 
       - name: Save Docker Image
-        run: docker save -o grh-website_${{ github.sha }}.tar grh-website:${{ github.sha }}
+        run: docker save -o grh-website_${{ github.sha }}.tar grh-website:latest-test
 
       - name: Set up SSH
         uses: webfactory/ssh-agent@v0.5.4


### PR DESCRIPTION
Updated the Docker save command to use the correct image tag 'latest-test' instead of the commit SHA. This ensures consistency with the previous Docker build step.